### PR TITLE
Always build bindings in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::process;
 fn main() {
     println!("cargo:rustc-link-lib=bcc");
     // Uncomment below to update binding
-    // build_bcc_bindings();
+    build_bcc_bindings();
 }
 
 const WHITELIST_FUNCTION: &'static [&'static str] = &["bpf_.*", "bcc_.*", "perf_reader_.*"];


### PR DESCRIPTION
I've been using `bcc-sys` to write more idiomatic Rust bindings (like the Python bcc bindings) for bcc in https://github.com/jvns/rust-bcc.

The issue I've run into is that the function signatures in the `bcc` header files change over time, and some important functions (like `bpf_attach_kprobe` and `bpf_attach_uprobe`) have changed.

Proposal: handle the changing functions (and make it easier for people to depend on `bcc-sys`). by having `bcc-sys` always build the bindings when it's compiled, instead of using cached bindings.

I'd like to publish `rust-bcc` as a crate to crates.io and have it depend on `bcc-sys` but I can't right now because the version on crates.io has bindings that don't match and so if I depend on `bcc-sys=0.5.0` `rust-bcc` won't compile. 