### PR TITLE
features misnamed in source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,188 @@
 language: rust
+dist: trusty
 rust:
   - stable
   - beta
   - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
-cache:
-  directories:
-    - $HOME/.cargo
-    - $TRAVIS_BUILD_DIR/target
-    - bcc
-before_install:
+script:
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
   - sudo apt-get update
   - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
   - git clone https://github.com/iovisor/bcc || true
-  - mkdir -p bcc/_build
-  - cd bcc/_build
-  - if [ ! -e Makefile ]; then cmake ..; fi
-  - make && sudo make install
+  - cd bcc
+  - git checkout master
+  - git pull
+  - git checkout remotes/origin/tag_v0.8.0
+  - mkdir -p _build
+  - cd _build
+  - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+  - make
+  - sudo make install
   - cd ../..
+  - cargo build
+  - cargo test
+  - cargo build --release
+  - cargo test --release
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+  include:
+    - os: linux
+      dist: trusty
+      rust: stable
+      env: BCC=v0_4_0 RUST_BACKTRACE=1
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+        - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+        - sudo apt-get update
+        - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout remotes/origin/tag_v0.4.0
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+    - os: linux
+      dist: trusty
+      rust: stable
+      env: BCC=v0_5_0 RUST_BACKTRACE=1
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+        - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+        - sudo apt-get update
+        - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout remotes/origin/tag_v0.5.0
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+    - os: linux
+      dist: trusty
+      rust: stable
+      env: BCC=v0_6_0 RUST_BACKTRACE=1
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+        - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+        - sudo apt-get update
+        - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout remotes/origin/tag_v0.6.0
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+    - os: linux
+      dist: trusty
+      rust: stable
+      env: BCC=v0_6_1 RUST_BACKTRACE=1
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+        - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+        - sudo apt-get update
+        - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout remotes/origin/tag_v0.6.1
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+    - os: linux
+      dist: trusty
+      rust: stable
+      env: BCC=v0_7_0 RUST_BACKTRACE=1
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+        - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+        - sudo apt-get update
+        - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout remotes/origin/tag_v0.7.0
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+    - os: linux
+      dist: trusty
+      rust: stable
+      env: BCC=v0_8_0 RUST_BACKTRACE=1
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+        - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+        - sudo apt-get update
+        - sudo apt-get --yes install bison build-essential cmake3 flex git libclang-common-5.0-dev libelf-dev libllvm5.0 libz-dev lldb-5.0 llvm-5.0 llvm-5.0-dev llvm-5.0-runtime
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout remotes/origin/tag_v0.8.0
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+cache:
+  directories:
+    - $HOME/.cargo
+    - $TRAVIS_BUILD_DIR/target
+    - bcc
+

--- a/src/bccapi/mod.rs
+++ b/src/bccapi/mod.rs
@@ -1,34 +1,55 @@
+#[cfg(feature = "v0_4_0")]
 mod v0_4_0;
+
+#[cfg(feature = "v0_5_0")]
 mod v0_5_0;
+
+#[cfg(feature = "v0_6_0")]
 mod v0_6_0;
+
+#[cfg(feature = "v0_6_1")]
 mod v0_6_1;
+
+#[cfg(feature = "v0_7_0")]
 mod v0_7_0;
+
+#[cfg(feature = "v0_8_0")]
 mod v0_8_0;
 
-#[cfg(feature = "0.4.0")]
+#[cfg(not(any(
+    feature = "v0_4_0",
+    feature = "v0_5_0",
+    feature = "v0_6_0",
+    feature = "v0_6_1",
+    feature = "v0_7_0",
+    feature = "v0_8_0"
+)))]
+mod v0_8_0;
+
+#[cfg(feature = "v0_4_0")]
 pub use v0_4_0::*;
 
-#[cfg(feature = "0.5.0")]
+#[cfg(feature = "v0_5_0")]
 pub use v0_5_0::*;
 
-#[cfg(feature = "0.6.0")]
+#[cfg(feature = "v0_6_0")]
 pub use v0_6_0::*;
 
-#[cfg(feature = "0.6.1")]
+#[cfg(feature = "v0_6_1")]
 pub use v0_6_1::*;
 
-#[cfg(feature = "0.7.0")]
+#[cfg(feature = "v0_7_0")]
 pub use v0_7_0::*;
 
-#[cfg(feature = "0.8.0")]
+#[cfg(feature = "v0_8_0")]
 pub use v0_8_0::*;
 
 #[cfg(not(any(
-    feature = "0.4.0",
-    feature = "0.5.0",
-    feature = "0.6.0",
-    feature = "0.6.1",
-    feature = "0.7.0",
-    feature = "0.8.0"
+    feature = "v0_4_0",
+    feature = "v0_5_0",
+    feature = "v0_6_0",
+    feature = "v0_6_1",
+    feature = "v0_7_0",
+    feature = "v0_8_0"
 )))]
 pub use v0_8_0::*;


### PR DESCRIPTION
* feature names in the source don't match resulting in defaulting to v0.8.0
* hide warnings by conditionally including the per-version modules
* extend the test matrix to test with other bcc versions