### PR TITLE
fix static linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Rust binding for [bcc](https://github.com/iovisor/bcc).
 * Version 0.7.1 reflects the 0.6.1 version of bcc.
 * Version 0.8.0 reflects bcc v0.4.0-v0.8.0 using feature flags.
 * Version 0.9.0 reflects bcc v0.4.0-v0.9.0 using feature flags.
+* Version 0.10.1 reflects bcc v0.4.0-v0.10.0 using feature flags.
 
 **Note:** If you do not specify a version of bcc using feature flags, the
 library will expect the latest version of bcc supported by the release of this

--- a/build.rs
+++ b/build.rs
@@ -134,7 +134,13 @@ fn linking_info() {
 
     println!("cargo:rustc-link-lib=static=bcc");
     println!("cargo:rustc-link-lib=static=bcc-loader-static");
-    println!("cargo:rustc-link-lib=static=bpf");
+    if cfg!(any(
+        feature = "v0_10_0",
+    )) {
+        println!("cargo:rustc-link-lib=static=bcc_bpf");
+    } else {
+        println!("cargo:rustc-link-lib=static=bpf");
+    }
     println!("cargo:rustc-link-lib=static=b_frontend");
     println!("cargo:rustc-link-lib=static=clang_frontend");
     println!("cargo:rustc-link-lib=static=usdt-static");


### PR DESCRIPTION
Fixes an issue with static linking. v0.10.0 renamed libbpf to
libbcc_bpf

Adds entry to supported versions list in README