### PR TITLE
fix static linking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,11 +135,17 @@ fn linking_info() {
     println!("cargo:rustc-link-lib=static=bcc");
     println!("cargo:rustc-link-lib=static=bcc-loader-static");
     if cfg!(any(
-        feature = "v0_10_0",
+        feature = "v0_4_0",
+        feature = "v0_5_0",
+        feature = "v0_6_0",
+        feature = "v0_6_1",
+        feature = "v0_7_0",
+        feature = "v0_8_0",
+        feature = "v0_9_0",
     )) {
-        println!("cargo:rustc-link-lib=static=bcc_bpf");
-    } else {
         println!("cargo:rustc-link-lib=static=bpf");
+    } else {
+        println!("cargo:rustc-link-lib=static=bcc_bpf");
     }
     println!("cargo:rustc-link-lib=static=b_frontend");
     println!("cargo:rustc-link-lib=static=clang_frontend");


### PR DESCRIPTION
Previous PR didn't address the default version properly, resulting
in linking still not working when no version specified via feature
flag. This fix changes the logic in selecting which library to
link so that we have a default case which is appropriate for the
default supported bcc version