### PR TITLE
fix static build

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -168,6 +168,57 @@ jobs:
       run: cargo build --release --features v0_15_0
     - name: test
       run: cargo test --release --features v0_15_0
+  focal-bcc_v0_15_0-static:
+    name: focal / llvm 9 / bcc 0.15.0 / static
+    runs-on: ubuntu-20.04
+    env:
+      CFLAGS: -fPIC
+      RUSTFLAGS: -L /usr/lib -L /usr/lib64 -L /usr/lib/llvm-9/lib
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: focal_nightly_bcc-0.15.0_static
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm-6.0* *clang-6.0* *llvm-10* *clang-10*
+    - name: install build deps
+      run: sudo apt-get install libelf-dev libclang-9-dev libfl-dev libxml2-dev llvm-9-dev
+    - name: fetch zlib
+      run: curl -L -O https://zlib.net/zlib-1.2.11.tar.gz
+    - name: build zlib
+      run: tar xzf zlib-1.2.11.tar.gz && cd zlib-1.2.11 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch xz
+      run: curl -L -O https://tukaani.org/xz/xz-5.2.5.tar.gz
+    - name: build xz
+      run: tar xzf xz-5.2.5.tar.gz && cd xz-5.2.5 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch ncurses
+      run: curl -L -O ftp://ftp.invisible-island.net/ncurses/ncurses-6.2.tar.gz
+    - name: build ncurses
+      run: tar xzf ncurses-6.2.tar.gz && cd ncurses-6.2 && ./configure --prefix=/usr --with-termlib && make -j2 && sudo make install
+    - name: clone libxml2
+      run: git clone https://gitlab.gnome.org/GNOME/libxml2 && cd libxml2 && git checkout 41a34e1f4ffae2ce401600dbb5fe43f8fe402641
+    - name: build libxml2
+      run: cd libxml2 && autoreconf -fvi && ./configure --prefix=/usr --without-python && make -j2 && sudo make install
+    - name: fetch elfutils
+      run: curl -L -O ftp://sourceware.org/pub/elfutils/0.180/elfutils-0.180.tar.bz2
+    - name: build elfutils
+      run: tar xjf elfutils-0.180.tar.bz2 && cd elfutils-0.180 && ./configure --prefix=/usr --disable-debuginfod && make -j2 && sudo make install
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout e41f7a3be5c8114ef6a0990e50c2fbabea0e928e
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install && find . -name "*.a" -exec sudo cp -v {} /usr/lib/ \;
+    - name: build
+      run: cargo build --release --features v0_15_0
+    - name: test
+      run: cargo test --release --features v0_15_0
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,73 @@ fn linking_info() {
     println!("cargo:rustc-link-lib=static=clang_frontend");
     println!("cargo:rustc-link-lib=static=usdt-static");
 
-    llvm_static_linking();
+    println!("cargo:rustc-link-lib=static=LLVMLTO");
+    println!("cargo:rustc-link-lib=static=LLVMPasses");
+    println!("cargo:rustc-link-lib=static=LLVMObjCARCOpts");
+    println!("cargo:rustc-link-lib=static=LLVMSymbolize");
+    println!("cargo:rustc-link-lib=static=LLVMDebugInfoPDB");
+    println!("cargo:rustc-link-lib=static=LLVMDebugInfoDWARF");
+    println!("cargo:rustc-link-lib=static=LLVMFuzzMutate");
+    println!("cargo:rustc-link-lib=static=LLVMMCA");
+    println!("cargo:rustc-link-lib=static=LLVMTableGen");
+    println!("cargo:rustc-link-lib=static=LLVMDlltoolDriver");
+    println!("cargo:rustc-link-lib=static=LLVMLineEditor");
+    println!("cargo:rustc-link-lib=static=LLVMXRay");
+    println!("cargo:rustc-link-lib=static=LLVMOrcJIT");
+    println!("cargo:rustc-link-lib=static=LLVMCoverage");
+    println!("cargo:rustc-link-lib=static=LLVMMIRParser");
+    println!("cargo:rustc-link-lib=static=LLVMBPFDisassembler");
+    println!("cargo:rustc-link-lib=static=LLVMBPFCodeGen");
+    println!("cargo:rustc-link-lib=static=LLVMBPFAsmParser");
+    println!("cargo:rustc-link-lib=static=LLVMBPFDesc");
+    println!("cargo:rustc-link-lib=static=LLVMBPFInfo");
+    println!("cargo:rustc-link-lib=static=LLVMObjectYAML");
+    println!("cargo:rustc-link-lib=static=LLVMLibDriver");
+    println!("cargo:rustc-link-lib=static=LLVMOption");
+    println!("cargo:rustc-link-lib=static=LLVMWindowsManifest");
+    println!("cargo:rustc-link-lib=static=LLVMTextAPI");
+    println!("cargo:rustc-link-lib=static=LLVMX86Disassembler");
+    println!("cargo:rustc-link-lib=static=LLVMX86AsmParser");
+    println!("cargo:rustc-link-lib=static=LLVMX86CodeGen");
+    println!("cargo:rustc-link-lib=static=LLVMGlobalISel");
+    println!("cargo:rustc-link-lib=static=LLVMSelectionDAG");
+    println!("cargo:rustc-link-lib=static=LLVMAsmPrinter");
+    println!("cargo:rustc-link-lib=static=LLVMX86Desc");
+    println!("cargo:rustc-link-lib=static=LLVMMCDisassembler");
+    println!("cargo:rustc-link-lib=static=LLVMX86Info");
+    println!("cargo:rustc-link-lib=static=LLVMX86Utils");
+    println!("cargo:rustc-link-lib=static=LLVMMCJIT");
+    println!("cargo:rustc-link-lib=static=LLVMInterpreter");
+    println!("cargo:rustc-link-lib=static=LLVMExecutionEngine");
+    println!("cargo:rustc-link-lib=static=LLVMRuntimeDyld");
+    println!("cargo:rustc-link-lib=static=LLVMCodeGen");
+    println!("cargo:rustc-link-lib=static=LLVMTarget");
+    println!("cargo:rustc-link-lib=static=LLVMCoroutines");
+    println!("cargo:rustc-link-lib=static=LLVMipo");
+    println!("cargo:rustc-link-lib=static=LLVMInstrumentation");
+    println!("cargo:rustc-link-lib=static=LLVMVectorize");
+    println!("cargo:rustc-link-lib=static=LLVMScalarOpts");
+    println!("cargo:rustc-link-lib=static=LLVMLinker");
+    println!("cargo:rustc-link-lib=static=LLVMIRReader");
+    println!("cargo:rustc-link-lib=static=LLVMAsmParser");
+    println!("cargo:rustc-link-lib=static=LLVMInstCombine");
+    println!("cargo:rustc-link-lib=static=LLVMBitWriter");
+    println!("cargo:rustc-link-lib=static=LLVMAggressiveInstCombine");
+    println!("cargo:rustc-link-lib=static=LLVMTransformUtils");
+    println!("cargo:rustc-link-lib=static=LLVMAnalysis");
+    println!("cargo:rustc-link-lib=static=LLVMProfileData");
+    println!("cargo:rustc-link-lib=static=LLVMObject");
+    println!("cargo:rustc-link-lib=static=LLVMMCParser");
+    println!("cargo:rustc-link-lib=static=LLVMMC");
+    println!("cargo:rustc-link-lib=static=LLVMDebugInfoCodeView");
+    println!("cargo:rustc-link-lib=static=LLVMDebugInfoMSF");
+    println!("cargo:rustc-link-lib=static=LLVMBitReader");
+    println!("cargo:rustc-link-lib=static=LLVMBitstreamReader");
+    println!("cargo:rustc-link-lib=static=LLVMCore");
+    println!("cargo:rustc-link-lib=static=LLVMBinaryFormat");
+    println!("cargo:rustc-link-lib=static=LLVMSupport");
+    println!("cargo:rustc-link-lib=static=LLVMDemangle");
+    println!("cargo:rustc-link-lib=static=LLVMRemarks");
 
     println!("cargo:rustc-link-lib=static=clangAnalysis");
     println!("cargo:rustc-link-lib=static=clangARCMigrate");
@@ -177,21 +243,4 @@ fn linking_info() {
     println!("cargo:rustc-link-lib=static=clangStaticAnalyzerFrontend");
     println!("cargo:rustc-link-lib=static=clangTooling");
     println!("cargo:rustc-link-lib=static=clangToolingCore");
-    println!("cargo:rustc-link-lib=static=clangToolingRefactor");
-}
-
-// this function generates the linking info for llvm
-#[allow(dead_code)]
-fn llvm_static_linking() {
-    let llvm_config = std::process::Command::new("llvm-config")
-        .arg("--libs")
-        .output()
-        .expect("failed to run llvm-config");
-    let llvm_libs = String::from_utf8(llvm_config.stdout)
-        .expect("llvm-config output contains non-utf8 characters");
-    let libs: Vec<&str> = llvm_libs.split_whitespace().collect();
-    for lib in libs {
-        let (_, name) = lib.split_at(2);
-        println!("cargo:rustc-link-lib=static={}", name);
-    }
 }


### PR DESCRIPTION
Static build is currently not tested and was broken on ubuntu focal w/ llvm 9.

Changes the linking in the build script to be explicit instead of using `llvm-config`. This gives us better control.

Adds a build to github workflow to test static build 