### PR TITLE
remove caching in ci

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CACHE: 0
 
 jobs:
   xenial-llvm_8-bcc_v0_10_0:
@@ -19,17 +18,6 @@ jobs:
       LLVM: 8
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name:  xenial-llvm_8-bcc_v0_10_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   xenial-llvm_8-bcc_v0_11_0:
@@ -42,17 +30,6 @@ jobs:
       LLVM: 8
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: xenial-llvm_8-bcc_v0_11_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   xenial-llvm_8-bcc_v0_12_0:
@@ -65,17 +42,6 @@ jobs:
       LLVM: 8
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: xenial-llvm_8-bcc_v0_12_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   xenial-llvm_8-bcc_v0_13_0:
@@ -88,17 +54,6 @@ jobs:
       LLVM: 8
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: xenial-llvm_8-bcc_v0_13_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   xenial-llvm_8-bcc_v0_14_0:
@@ -111,17 +66,6 @@ jobs:
       LLVM: 8
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: xenial-llvm_8-bcc_v0_14_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   xenial-llvm_8-bcc_v0_15_0:
@@ -134,17 +78,6 @@ jobs:
       LLVM: 8
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: xenial-llvm_8-bcc_v0_15_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   xenial-llvm_8-bcc_v0_15_0-static:
@@ -158,17 +91,6 @@ jobs:
       STATIC: true
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: xenial-llvm_8-bcc_v0_15_0-static
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Run CI
       run: bash -e build/ci.sh
   focal-llvm_9-bcc_v0_12_0:
@@ -181,17 +103,6 @@ jobs:
       LLVM: 9
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: focal-llvm_9-bcc_v0_12_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   focal-llvm_9-bcc_v0_13_0:
@@ -204,17 +115,6 @@ jobs:
       LLVM: 9
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: focal-llvm_9-bcc_v0_13_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   focal-llvm_9-bcc_v0_14_0:
@@ -227,17 +127,6 @@ jobs:
       LLVM: 9
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: focal-llvm_9-bcc_v0_14_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   focal-llvm_9-bcc_v0_15_0:
@@ -250,17 +139,6 @@ jobs:
       LLVM: 9
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: focal-llvm_9-bcc_v0_15_0
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Run CI
       run: bash -e build/ci.sh
   focal-llvm_9-bcc_v0_15_0-static:
@@ -274,34 +152,12 @@ jobs:
       STATIC: true
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: focal_nightly_bcc-0.15.0_static
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Run CI
       run: bash -e build/ci.sh
   rustfmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: rustfmt
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: install rustfmt
       run: rustup component add rustfmt
     - name: rustfmt
@@ -310,17 +166,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      env:
-        cache-name: clippy
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/.cargo/bin
-          ~/.cargo/git
-          ~/.cargo/registry
-          target
-        key: ${{ env.cache-name }}-${{ env.cache }}-${{ hashFiles('**/Cargo.toml') }}
     - name: install clippy
       run: rustup component add clippy
     - name: clippy

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -2,26 +2,6 @@
 
 set -e
 
-# try to install or use existing sccache
-export SCCACHE=false
-
-if sccache --version > /dev/null 2>&1; then
-    echo "Using existing sccache"
-    export SCCACHE=true
-elif cargo install sccache; then
-    echo "Installed sccache"
-    export SCCACHE=true
-else
-    echo "Building without sccache"
-fi
-
-if [[ $SCCACHE == true ]]; then
-    export RUSTC_WRAPPER="sccache"
-    export CC="sccache gcc"
-    export CXX="sccache g++"
-    sccache --version
-fi
-
 ## Update apt
 sudo apt-get update
 


### PR DESCRIPTION
We're not getting cache hits anyway right now. This will simplify
the config significantly by just removing the caching. This also
reduces the runtime as sccache will not need to build.
