### PR TITLE
regenerate bcc 0.20.0 bindings

### DIFF
--- a/src/bccapi/v0_20_0.rs
+++ b/src/bccapi/v0_20_0.rs
@@ -80,6 +80,36 @@ where
         }
     }
 }
+#[repr(C)]
+#[derive(Default)]
+pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+impl<T> __IncompleteArrayField<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        __IncompleteArrayField(::std::marker::PhantomData, [])
+    }
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
+    }
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
+    }
+    #[inline]
+    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
+        ::std::slice::from_raw_parts(self.as_ptr(), len)
+    }
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
+        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+    }
+}
+impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fmt.write_str("__IncompleteArrayField")
+    }
+}
 pub const BPF_LD: u32 = 0;
 pub const BPF_LDX: u32 = 1;
 pub const BPF_ST: u32 = 2;
@@ -127,34 +157,73 @@ pub const BPF_TO_BE: u32 = 8;
 pub const BPF_FROM_LE: u32 = 0;
 pub const BPF_FROM_BE: u32 = 8;
 pub const BPF_JNE: u32 = 80;
+pub const BPF_JLT: u32 = 160;
+pub const BPF_JLE: u32 = 176;
 pub const BPF_JSGT: u32 = 96;
 pub const BPF_JSGE: u32 = 112;
+pub const BPF_JSLT: u32 = 192;
+pub const BPF_JSLE: u32 = 208;
 pub const BPF_CALL: u32 = 128;
 pub const BPF_EXIT: u32 = 144;
+pub const BPF_F_ALLOW_OVERRIDE: u32 = 1;
+pub const BPF_F_ALLOW_MULTI: u32 = 2;
+pub const BPF_F_STRICT_ALIGNMENT: u32 = 1;
+pub const BPF_F_ANY_ALIGNMENT: u32 = 2;
 pub const BPF_PSEUDO_MAP_FD: u32 = 1;
+pub const BPF_PSEUDO_CALL: u32 = 1;
 pub const BPF_ANY: u32 = 0;
 pub const BPF_NOEXIST: u32 = 1;
 pub const BPF_EXIST: u32 = 2;
 pub const BPF_F_NO_PREALLOC: u32 = 1;
+pub const BPF_F_NO_COMMON_LRU: u32 = 2;
+pub const BPF_F_NUMA_NODE: u32 = 4;
+pub const BPF_F_QUERY_EFFECTIVE: u32 = 1;
+pub const BPF_OBJ_NAME_LEN: u32 = 16;
+pub const BPF_F_RDONLY: u32 = 8;
+pub const BPF_F_WRONLY: u32 = 16;
+pub const BPF_F_STACK_BUILD_ID: u32 = 32;
+pub const BPF_BUILD_ID_SIZE: u32 = 20;
 pub const BPF_F_RECOMPUTE_CSUM: u32 = 1;
 pub const BPF_F_INVALIDATE_HASH: u32 = 2;
 pub const BPF_F_HDR_FIELD_MASK: u32 = 15;
 pub const BPF_F_PSEUDO_HDR: u32 = 16;
 pub const BPF_F_MARK_MANGLED_0: u32 = 32;
+pub const BPF_F_MARK_ENFORCE: u32 = 64;
 pub const BPF_F_INGRESS: u32 = 1;
 pub const BPF_F_TUNINFO_IPV6: u32 = 1;
 pub const BPF_F_SKIP_FIELD_MASK: u32 = 255;
 pub const BPF_F_USER_STACK: u32 = 256;
 pub const BPF_F_FAST_STACK_CMP: u32 = 512;
 pub const BPF_F_REUSE_STACKID: u32 = 1024;
+pub const BPF_F_USER_BUILD_ID: u32 = 2048;
 pub const BPF_F_ZERO_CSUM_TX: u32 = 2;
 pub const BPF_F_DONT_FRAGMENT: u32 = 4;
+pub const BPF_F_SEQ_NUMBER: u32 = 8;
 pub const BPF_F_INDEX_MASK: u32 = 4294967295;
 pub const BPF_F_CURRENT_CPU: u32 = 4294967295;
 pub const BPF_F_CTXLEN_MASK: u64 = 4503595332403200;
+pub const XDP_PACKET_HEADROOM: u32 = 256;
+pub const BPF_TAG_SIZE: u32 = 8;
+pub const BPF_SOCK_OPS_RTO_CB_FLAG: u32 = 1;
+pub const BPF_SOCK_OPS_RETRANS_CB_FLAG: u32 = 2;
+pub const BPF_SOCK_OPS_STATE_CB_FLAG: u32 = 4;
+pub const BPF_SOCK_OPS_ALL_CB_FLAGS: u32 = 7;
+pub const TCP_BPF_IW: u32 = 1001;
+pub const TCP_BPF_SNDCWND_CLAMP: u32 = 1002;
+pub const BPF_DEVCG_ACC_MKNOD: u32 = 1;
+pub const BPF_DEVCG_ACC_READ: u32 = 2;
+pub const BPF_DEVCG_ACC_WRITE: u32 = 4;
+pub const BPF_DEVCG_DEV_BLOCK: u32 = 1;
+pub const BPF_DEVCG_DEV_CHAR: u32 = 2;
+pub const BPF_FIB_LOOKUP_DIRECT: u32 = 1;
+pub const BPF_FIB_LOOKUP_OUTPUT: u32 = 2;
 pub const LOG_BUF_SIZE: u32 = 65536;
 pub const BPF_FN_PREFIX: &'static [u8; 9usize] = b".bpf.fn.\0";
 pub const STT_GNU_IFUNC: u32 = 10;
+pub type __uint8_t = ::std::os::raw::c_uchar;
+pub type __int16_t = ::std::os::raw::c_short;
+pub type __uint32_t = ::std::os::raw::c_uint;
+pub type __uint64_t = ::std::os::raw::c_ulong;
 pub type __pid_t = ::std::os::raw::c_int;
 pub type pid_t = __pid_t;
 extern "C" {
@@ -394,6 +463,8 @@ pub type __u16 = ::std::os::raw::c_ushort;
 pub type __s32 = ::std::os::raw::c_int;
 pub type __u32 = ::std::os::raw::c_uint;
 pub type __u64 = ::std::os::raw::c_ulonglong;
+pub type __be16 = __u16;
+pub type __be32 = __u32;
 pub const BPF_REG_0: ::std::os::raw::c_uint = 0;
 pub const BPF_REG_1: ::std::os::raw::c_uint = 1;
 pub const BPF_REG_2: ::std::os::raw::c_uint = 2;
@@ -496,6 +567,88 @@ impl bpf_insn {
         __bindgen_bitfield_unit
     }
 }
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct bpf_lpm_trie_key {
+    pub prefixlen: __u32,
+    pub data: __IncompleteArrayField<__u8>,
+}
+#[test]
+fn bindgen_test_layout_bpf_lpm_trie_key() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_lpm_trie_key>(),
+        4usize,
+        concat!("Size of: ", stringify!(bpf_lpm_trie_key))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_lpm_trie_key>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_lpm_trie_key))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_lpm_trie_key>())).prefixlen as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_lpm_trie_key),
+            "::",
+            stringify!(prefixlen)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_lpm_trie_key>())).data as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_lpm_trie_key),
+            "::",
+            stringify!(data)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_cgroup_storage_key {
+    pub cgroup_inode_id: __u64,
+    pub attach_type: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_cgroup_storage_key() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_cgroup_storage_key>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_cgroup_storage_key))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_cgroup_storage_key>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_cgroup_storage_key))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_cgroup_storage_key>())).cgroup_inode_id as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_cgroup_storage_key),
+            "::",
+            stringify!(cgroup_inode_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_cgroup_storage_key>())).attach_type as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_cgroup_storage_key),
+            "::",
+            stringify!(attach_type)
+        )
+    );
+}
 pub const bpf_cmd_BPF_MAP_CREATE: bpf_cmd = 0;
 pub const bpf_cmd_BPF_MAP_LOOKUP_ELEM: bpf_cmd = 1;
 pub const bpf_cmd_BPF_MAP_UPDATE_ELEM: bpf_cmd = 2;
@@ -504,6 +657,19 @@ pub const bpf_cmd_BPF_MAP_GET_NEXT_KEY: bpf_cmd = 4;
 pub const bpf_cmd_BPF_PROG_LOAD: bpf_cmd = 5;
 pub const bpf_cmd_BPF_OBJ_PIN: bpf_cmd = 6;
 pub const bpf_cmd_BPF_OBJ_GET: bpf_cmd = 7;
+pub const bpf_cmd_BPF_PROG_ATTACH: bpf_cmd = 8;
+pub const bpf_cmd_BPF_PROG_DETACH: bpf_cmd = 9;
+pub const bpf_cmd_BPF_PROG_TEST_RUN: bpf_cmd = 10;
+pub const bpf_cmd_BPF_PROG_GET_NEXT_ID: bpf_cmd = 11;
+pub const bpf_cmd_BPF_MAP_GET_NEXT_ID: bpf_cmd = 12;
+pub const bpf_cmd_BPF_PROG_GET_FD_BY_ID: bpf_cmd = 13;
+pub const bpf_cmd_BPF_MAP_GET_FD_BY_ID: bpf_cmd = 14;
+pub const bpf_cmd_BPF_OBJ_GET_INFO_BY_FD: bpf_cmd = 15;
+pub const bpf_cmd_BPF_PROG_QUERY: bpf_cmd = 16;
+pub const bpf_cmd_BPF_RAW_TRACEPOINT_OPEN: bpf_cmd = 17;
+pub const bpf_cmd_BPF_BTF_LOAD: bpf_cmd = 18;
+pub const bpf_cmd_BPF_BTF_GET_FD_BY_ID: bpf_cmd = 19;
+pub const bpf_cmd_BPF_TASK_FD_QUERY: bpf_cmd = 20;
 pub type bpf_cmd = ::std::os::raw::c_uint;
 pub const bpf_map_type_BPF_MAP_TYPE_UNSPEC: bpf_map_type = 0;
 pub const bpf_map_type_BPF_MAP_TYPE_HASH: bpf_map_type = 1;
@@ -514,6 +680,18 @@ pub const bpf_map_type_BPF_MAP_TYPE_PERCPU_HASH: bpf_map_type = 5;
 pub const bpf_map_type_BPF_MAP_TYPE_PERCPU_ARRAY: bpf_map_type = 6;
 pub const bpf_map_type_BPF_MAP_TYPE_STACK_TRACE: bpf_map_type = 7;
 pub const bpf_map_type_BPF_MAP_TYPE_CGROUP_ARRAY: bpf_map_type = 8;
+pub const bpf_map_type_BPF_MAP_TYPE_LRU_HASH: bpf_map_type = 9;
+pub const bpf_map_type_BPF_MAP_TYPE_LRU_PERCPU_HASH: bpf_map_type = 10;
+pub const bpf_map_type_BPF_MAP_TYPE_LPM_TRIE: bpf_map_type = 11;
+pub const bpf_map_type_BPF_MAP_TYPE_ARRAY_OF_MAPS: bpf_map_type = 12;
+pub const bpf_map_type_BPF_MAP_TYPE_HASH_OF_MAPS: bpf_map_type = 13;
+pub const bpf_map_type_BPF_MAP_TYPE_DEVMAP: bpf_map_type = 14;
+pub const bpf_map_type_BPF_MAP_TYPE_SOCKMAP: bpf_map_type = 15;
+pub const bpf_map_type_BPF_MAP_TYPE_CPUMAP: bpf_map_type = 16;
+pub const bpf_map_type_BPF_MAP_TYPE_XSKMAP: bpf_map_type = 17;
+pub const bpf_map_type_BPF_MAP_TYPE_SOCKHASH: bpf_map_type = 18;
+pub const bpf_map_type_BPF_MAP_TYPE_CGROUP_STORAGE: bpf_map_type = 19;
+pub const bpf_map_type_BPF_MAP_TYPE_REUSEPORT_SOCKARRAY: bpf_map_type = 20;
 pub type bpf_map_type = ::std::os::raw::c_uint;
 pub const bpf_prog_type_BPF_PROG_TYPE_UNSPEC: bpf_prog_type = 0;
 pub const bpf_prog_type_BPF_PROG_TYPE_SOCKET_FILTER: bpf_prog_type = 1;
@@ -523,7 +701,164 @@ pub const bpf_prog_type_BPF_PROG_TYPE_SCHED_ACT: bpf_prog_type = 4;
 pub const bpf_prog_type_BPF_PROG_TYPE_TRACEPOINT: bpf_prog_type = 5;
 pub const bpf_prog_type_BPF_PROG_TYPE_XDP: bpf_prog_type = 6;
 pub const bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT: bpf_prog_type = 7;
+pub const bpf_prog_type_BPF_PROG_TYPE_CGROUP_SKB: bpf_prog_type = 8;
+pub const bpf_prog_type_BPF_PROG_TYPE_CGROUP_SOCK: bpf_prog_type = 9;
+pub const bpf_prog_type_BPF_PROG_TYPE_LWT_IN: bpf_prog_type = 10;
+pub const bpf_prog_type_BPF_PROG_TYPE_LWT_OUT: bpf_prog_type = 11;
+pub const bpf_prog_type_BPF_PROG_TYPE_LWT_XMIT: bpf_prog_type = 12;
+pub const bpf_prog_type_BPF_PROG_TYPE_SOCK_OPS: bpf_prog_type = 13;
+pub const bpf_prog_type_BPF_PROG_TYPE_SK_SKB: bpf_prog_type = 14;
+pub const bpf_prog_type_BPF_PROG_TYPE_CGROUP_DEVICE: bpf_prog_type = 15;
+pub const bpf_prog_type_BPF_PROG_TYPE_SK_MSG: bpf_prog_type = 16;
+pub const bpf_prog_type_BPF_PROG_TYPE_RAW_TRACEPOINT: bpf_prog_type = 17;
+pub const bpf_prog_type_BPF_PROG_TYPE_CGROUP_SOCK_ADDR: bpf_prog_type = 18;
+pub const bpf_prog_type_BPF_PROG_TYPE_LWT_SEG6LOCAL: bpf_prog_type = 19;
+pub const bpf_prog_type_BPF_PROG_TYPE_LIRC_MODE2: bpf_prog_type = 20;
+pub const bpf_prog_type_BPF_PROG_TYPE_SK_REUSEPORT: bpf_prog_type = 21;
 pub type bpf_prog_type = ::std::os::raw::c_uint;
+pub const bpf_attach_type_BPF_CGROUP_INET_INGRESS: bpf_attach_type = 0;
+pub const bpf_attach_type_BPF_CGROUP_INET_EGRESS: bpf_attach_type = 1;
+pub const bpf_attach_type_BPF_CGROUP_INET_SOCK_CREATE: bpf_attach_type = 2;
+pub const bpf_attach_type_BPF_CGROUP_SOCK_OPS: bpf_attach_type = 3;
+pub const bpf_attach_type_BPF_SK_SKB_STREAM_PARSER: bpf_attach_type = 4;
+pub const bpf_attach_type_BPF_SK_SKB_STREAM_VERDICT: bpf_attach_type = 5;
+pub const bpf_attach_type_BPF_CGROUP_DEVICE: bpf_attach_type = 6;
+pub const bpf_attach_type_BPF_SK_MSG_VERDICT: bpf_attach_type = 7;
+pub const bpf_attach_type_BPF_CGROUP_INET4_BIND: bpf_attach_type = 8;
+pub const bpf_attach_type_BPF_CGROUP_INET6_BIND: bpf_attach_type = 9;
+pub const bpf_attach_type_BPF_CGROUP_INET4_CONNECT: bpf_attach_type = 10;
+pub const bpf_attach_type_BPF_CGROUP_INET6_CONNECT: bpf_attach_type = 11;
+pub const bpf_attach_type_BPF_CGROUP_INET4_POST_BIND: bpf_attach_type = 12;
+pub const bpf_attach_type_BPF_CGROUP_INET6_POST_BIND: bpf_attach_type = 13;
+pub const bpf_attach_type_BPF_CGROUP_UDP4_SENDMSG: bpf_attach_type = 14;
+pub const bpf_attach_type_BPF_CGROUP_UDP6_SENDMSG: bpf_attach_type = 15;
+pub const bpf_attach_type_BPF_LIRC_MODE2: bpf_attach_type = 16;
+pub const bpf_attach_type_BPF_CGROUP_UDP4_RECVMSG: bpf_attach_type = 19;
+pub const bpf_attach_type_BPF_CGROUP_UDP6_RECVMSG: bpf_attach_type = 20;
+pub const bpf_attach_type___MAX_BPF_ATTACH_TYPE: bpf_attach_type = 21;
+pub type bpf_attach_type = ::std::os::raw::c_uint;
+pub const bpf_stack_build_id_status_BPF_STACK_BUILD_ID_EMPTY: bpf_stack_build_id_status = 0;
+pub const bpf_stack_build_id_status_BPF_STACK_BUILD_ID_VALID: bpf_stack_build_id_status = 1;
+pub const bpf_stack_build_id_status_BPF_STACK_BUILD_ID_IP: bpf_stack_build_id_status = 2;
+pub type bpf_stack_build_id_status = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_stack_build_id {
+    pub status: __s32,
+    pub build_id: [::std::os::raw::c_uchar; 20usize],
+    pub __bindgen_anon_1: bpf_stack_build_id__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_stack_build_id__bindgen_ty_1 {
+    pub offset: __u64,
+    pub ip: __u64,
+}
+#[test]
+fn bindgen_test_layout_bpf_stack_build_id__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_stack_build_id__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(bpf_stack_build_id__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_stack_build_id__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(bpf_stack_build_id__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_stack_build_id__bindgen_ty_1>())).offset as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_stack_build_id__bindgen_ty_1),
+            "::",
+            stringify!(offset)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_stack_build_id__bindgen_ty_1>())).ip as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_stack_build_id__bindgen_ty_1),
+            "::",
+            stringify!(ip)
+        )
+    );
+}
+impl Default for bpf_stack_build_id__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_stack_build_id__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_stack_build_id__bindgen_ty_1 {{ union }}")
+    }
+}
+#[test]
+fn bindgen_test_layout_bpf_stack_build_id() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_stack_build_id>(),
+        32usize,
+        concat!("Size of: ", stringify!(bpf_stack_build_id))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_stack_build_id>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_stack_build_id))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_stack_build_id>())).status as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_stack_build_id),
+            "::",
+            stringify!(status)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_stack_build_id>())).build_id as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_stack_build_id),
+            "::",
+            stringify!(build_id)
+        )
+    );
+}
+impl Default for bpf_stack_build_id {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_stack_build_id {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "bpf_stack_build_id {{ status: {:?}, build_id: {:?}, __bindgen_anon_1: {:?} }}",
+            self.status, self.build_id, self.__bindgen_anon_1
+        )
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union bpf_attr {
@@ -531,6 +866,14 @@ pub union bpf_attr {
     pub __bindgen_anon_2: bpf_attr__bindgen_ty_2,
     pub __bindgen_anon_3: bpf_attr__bindgen_ty_3,
     pub __bindgen_anon_4: bpf_attr__bindgen_ty_4,
+    pub __bindgen_anon_5: bpf_attr__bindgen_ty_5,
+    pub test: bpf_attr__bindgen_ty_6,
+    pub __bindgen_anon_6: bpf_attr__bindgen_ty_7,
+    pub info: bpf_attr__bindgen_ty_8,
+    pub query: bpf_attr__bindgen_ty_9,
+    pub raw_tracepoint: bpf_attr__bindgen_ty_10,
+    pub __bindgen_anon_7: bpf_attr__bindgen_ty_11,
+    pub task_fd_query: bpf_attr__bindgen_ty_12,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -540,12 +883,19 @@ pub struct bpf_attr__bindgen_ty_1 {
     pub value_size: __u32,
     pub max_entries: __u32,
     pub map_flags: __u32,
+    pub inner_map_fd: __u32,
+    pub numa_node: __u32,
+    pub map_name: [::std::os::raw::c_char; 16usize],
+    pub map_ifindex: __u32,
+    pub btf_fd: __u32,
+    pub btf_key_type_id: __u32,
+    pub btf_value_type_id: __u32,
 }
 #[test]
 fn bindgen_test_layout_bpf_attr__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<bpf_attr__bindgen_ty_1>(),
-        20usize,
+        60usize,
         concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_1))
     );
     assert_eq!(
@@ -607,6 +957,87 @@ fn bindgen_test_layout_bpf_attr__bindgen_ty_1() {
             stringify!(bpf_attr__bindgen_ty_1),
             "::",
             stringify!(map_flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).inner_map_fd as *const _ as usize
+        },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(inner_map_fd)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).numa_node as *const _ as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(numa_node)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).map_name as *const _ as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(map_name)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).map_ifindex as *const _ as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(map_ifindex)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).btf_fd as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(btf_fd)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).btf_key_type_id as *const _ as usize
+        },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(btf_key_type_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_1>())).btf_value_type_id as *const _
+                as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_1),
+            "::",
+            stringify!(btf_value_type_id)
         )
     );
 }
@@ -751,12 +1182,16 @@ pub struct bpf_attr__bindgen_ty_3 {
     pub log_size: __u32,
     pub log_buf: __u64,
     pub kern_version: __u32,
+    pub prog_flags: __u32,
+    pub prog_name: [::std::os::raw::c_char; 16usize],
+    pub prog_ifindex: __u32,
+    pub expected_attach_type: __u32,
 }
 #[test]
 fn bindgen_test_layout_bpf_attr__bindgen_ty_3() {
     assert_eq!(
         ::std::mem::size_of::<bpf_attr__bindgen_ty_3>(),
-        48usize,
+        72usize,
         concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_3))
     );
     assert_eq!(
@@ -850,12 +1285,62 @@ fn bindgen_test_layout_bpf_attr__bindgen_ty_3() {
             stringify!(kern_version)
         )
     );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_3>())).prog_flags as *const _ as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_3),
+            "::",
+            stringify!(prog_flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_3>())).prog_name as *const _ as usize
+        },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_3),
+            "::",
+            stringify!(prog_name)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_3>())).prog_ifindex as *const _ as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_3),
+            "::",
+            stringify!(prog_ifindex)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_3>())).expected_attach_type as *const _
+                as usize
+        },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_3),
+            "::",
+            stringify!(expected_attach_type)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct bpf_attr__bindgen_ty_4 {
     pub pathname: __u64,
     pub bpf_fd: __u32,
+    pub file_flags: __u32,
 }
 #[test]
 fn bindgen_test_layout_bpf_attr__bindgen_ty_4() {
@@ -889,18 +1374,791 @@ fn bindgen_test_layout_bpf_attr__bindgen_ty_4() {
             stringify!(bpf_fd)
         )
     );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_4>())).file_flags as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_4),
+            "::",
+            stringify!(file_flags)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_5 {
+    pub target_fd: __u32,
+    pub attach_bpf_fd: __u32,
+    pub attach_type: __u32,
+    pub attach_flags: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_5() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_5>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_5))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_5>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_5))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_5>())).target_fd as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_5),
+            "::",
+            stringify!(target_fd)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_5>())).attach_bpf_fd as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_5),
+            "::",
+            stringify!(attach_bpf_fd)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_5>())).attach_type as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_5),
+            "::",
+            stringify!(attach_type)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_5>())).attach_flags as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_5),
+            "::",
+            stringify!(attach_flags)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_6 {
+    pub prog_fd: __u32,
+    pub retval: __u32,
+    pub data_size_in: __u32,
+    pub data_size_out: __u32,
+    pub data_in: __u64,
+    pub data_out: __u64,
+    pub repeat: __u32,
+    pub duration: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_6() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_6>(),
+        40usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_6))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_6>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_6))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).prog_fd as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(prog_fd)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).retval as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(retval)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).data_size_in as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(data_size_in)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).data_size_out as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(data_size_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).data_in as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(data_in)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).data_out as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(data_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).repeat as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(repeat)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_6>())).duration as *const _ as usize },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_6),
+            "::",
+            stringify!(duration)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_attr__bindgen_ty_7 {
+    pub __bindgen_anon_1: bpf_attr__bindgen_ty_7__bindgen_ty_1,
+    pub next_id: __u32,
+    pub open_flags: __u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_attr__bindgen_ty_7__bindgen_ty_1 {
+    pub start_id: __u32,
+    pub prog_id: __u32,
+    pub map_id: __u32,
+    pub btf_id: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_7__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_7__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Size of: ",
+            stringify!(bpf_attr__bindgen_ty_7__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_7__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(bpf_attr__bindgen_ty_7__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_7__bindgen_ty_1>())).start_id as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_7__bindgen_ty_1),
+            "::",
+            stringify!(start_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_7__bindgen_ty_1>())).prog_id as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_7__bindgen_ty_1),
+            "::",
+            stringify!(prog_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_7__bindgen_ty_1>())).map_id as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_7__bindgen_ty_1),
+            "::",
+            stringify!(map_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_7__bindgen_ty_1>())).btf_id as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_7__bindgen_ty_1),
+            "::",
+            stringify!(btf_id)
+        )
+    );
+}
+impl Default for bpf_attr__bindgen_ty_7__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_attr__bindgen_ty_7__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_attr__bindgen_ty_7__bindgen_ty_1 {{ union }}")
+    }
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_7() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_7>(),
+        12usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_7))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_7>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_7))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_7>())).next_id as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_7),
+            "::",
+            stringify!(next_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_7>())).open_flags as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_7),
+            "::",
+            stringify!(open_flags)
+        )
+    );
+}
+impl Default for bpf_attr__bindgen_ty_7 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_attr__bindgen_ty_7 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(
+            f,
+            "bpf_attr__bindgen_ty_7 {{ __bindgen_anon_1: {:?}, next_id: {:?}, open_flags: {:?} }}",
+            self.__bindgen_anon_1, self.next_id, self.open_flags
+        )
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_8 {
+    pub bpf_fd: __u32,
+    pub info_len: __u32,
+    pub info: __u64,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_8() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_8>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_8))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_8>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_8))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_8>())).bpf_fd as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_8),
+            "::",
+            stringify!(bpf_fd)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_8>())).info_len as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_8),
+            "::",
+            stringify!(info_len)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_8>())).info as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_8),
+            "::",
+            stringify!(info)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_9 {
+    pub target_fd: __u32,
+    pub attach_type: __u32,
+    pub query_flags: __u32,
+    pub attach_flags: __u32,
+    pub prog_ids: __u64,
+    pub prog_cnt: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_9() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_9>(),
+        32usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_9))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_9>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_9))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_9>())).target_fd as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_9),
+            "::",
+            stringify!(target_fd)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_9>())).attach_type as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_9),
+            "::",
+            stringify!(attach_type)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_9>())).query_flags as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_9),
+            "::",
+            stringify!(query_flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_9>())).attach_flags as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_9),
+            "::",
+            stringify!(attach_flags)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_9>())).prog_ids as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_9),
+            "::",
+            stringify!(prog_ids)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_9>())).prog_cnt as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_9),
+            "::",
+            stringify!(prog_cnt)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_10 {
+    pub name: __u64,
+    pub prog_fd: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_10() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_10>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_10))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_10>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_10))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_10>())).name as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_10),
+            "::",
+            stringify!(name)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_10>())).prog_fd as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_10),
+            "::",
+            stringify!(prog_fd)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_11 {
+    pub btf: __u64,
+    pub btf_log_buf: __u64,
+    pub btf_size: __u32,
+    pub btf_log_size: __u32,
+    pub btf_log_level: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_11() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_11>(),
+        32usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_11))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_11>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_11))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_11>())).btf as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_11),
+            "::",
+            stringify!(btf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_11>())).btf_log_buf as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_11),
+            "::",
+            stringify!(btf_log_buf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_11>())).btf_size as *const _ as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_11),
+            "::",
+            stringify!(btf_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_11>())).btf_log_size as *const _ as usize
+        },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_11),
+            "::",
+            stringify!(btf_log_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_11>())).btf_log_level as *const _ as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_11),
+            "::",
+            stringify!(btf_log_level)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_attr__bindgen_ty_12 {
+    pub pid: __u32,
+    pub fd: __u32,
+    pub flags: __u32,
+    pub buf_len: __u32,
+    pub buf: __u64,
+    pub prog_id: __u32,
+    pub fd_type: __u32,
+    pub probe_offset: __u64,
+    pub probe_addr: __u64,
+}
+#[test]
+fn bindgen_test_layout_bpf_attr__bindgen_ty_12() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_attr__bindgen_ty_12>(),
+        48usize,
+        concat!("Size of: ", stringify!(bpf_attr__bindgen_ty_12))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_attr__bindgen_ty_12>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_attr__bindgen_ty_12))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).pid as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(pid)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).fd as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(fd)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).flags as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(flags)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).buf_len as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(buf_len)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).buf as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(buf)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).prog_id as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(prog_id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).fd_type as *const _ as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(fd_type)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).probe_offset as *const _ as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(probe_offset)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_attr__bindgen_ty_12>())).probe_addr as *const _ as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr__bindgen_ty_12),
+            "::",
+            stringify!(probe_addr)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_bpf_attr() {
     assert_eq!(
         ::std::mem::size_of::<bpf_attr>(),
-        48usize,
+        72usize,
         concat!("Size of: ", stringify!(bpf_attr))
     );
     assert_eq!(
         ::std::mem::align_of::<bpf_attr>(),
         8usize,
         concat!("Alignment of ", stringify!(bpf_attr))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr>())).test as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr),
+            "::",
+            stringify!(test)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr>())).info as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr),
+            "::",
+            stringify!(info)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr>())).query as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr),
+            "::",
+            stringify!(query)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr>())).raw_tracepoint as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr),
+            "::",
+            stringify!(raw_tracepoint)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_attr>())).task_fd_query as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_attr),
+            "::",
+            stringify!(task_fd_query)
+        )
     );
 }
 impl Default for bpf_attr {
@@ -959,8 +2217,58 @@ pub const bpf_func_id_BPF_FUNC_skb_change_tail: bpf_func_id = 38;
 pub const bpf_func_id_BPF_FUNC_skb_pull_data: bpf_func_id = 39;
 pub const bpf_func_id_BPF_FUNC_csum_update: bpf_func_id = 40;
 pub const bpf_func_id_BPF_FUNC_set_hash_invalid: bpf_func_id = 41;
-pub const bpf_func_id___BPF_FUNC_MAX_ID: bpf_func_id = 42;
+pub const bpf_func_id_BPF_FUNC_get_numa_node_id: bpf_func_id = 42;
+pub const bpf_func_id_BPF_FUNC_skb_change_head: bpf_func_id = 43;
+pub const bpf_func_id_BPF_FUNC_xdp_adjust_head: bpf_func_id = 44;
+pub const bpf_func_id_BPF_FUNC_probe_read_str: bpf_func_id = 45;
+pub const bpf_func_id_BPF_FUNC_get_socket_cookie: bpf_func_id = 46;
+pub const bpf_func_id_BPF_FUNC_get_socket_uid: bpf_func_id = 47;
+pub const bpf_func_id_BPF_FUNC_set_hash: bpf_func_id = 48;
+pub const bpf_func_id_BPF_FUNC_setsockopt: bpf_func_id = 49;
+pub const bpf_func_id_BPF_FUNC_skb_adjust_room: bpf_func_id = 50;
+pub const bpf_func_id_BPF_FUNC_redirect_map: bpf_func_id = 51;
+pub const bpf_func_id_BPF_FUNC_sk_redirect_map: bpf_func_id = 52;
+pub const bpf_func_id_BPF_FUNC_sock_map_update: bpf_func_id = 53;
+pub const bpf_func_id_BPF_FUNC_xdp_adjust_meta: bpf_func_id = 54;
+pub const bpf_func_id_BPF_FUNC_perf_event_read_value: bpf_func_id = 55;
+pub const bpf_func_id_BPF_FUNC_perf_prog_read_value: bpf_func_id = 56;
+pub const bpf_func_id_BPF_FUNC_getsockopt: bpf_func_id = 57;
+pub const bpf_func_id_BPF_FUNC_override_return: bpf_func_id = 58;
+pub const bpf_func_id_BPF_FUNC_sock_ops_cb_flags_set: bpf_func_id = 59;
+pub const bpf_func_id_BPF_FUNC_msg_redirect_map: bpf_func_id = 60;
+pub const bpf_func_id_BPF_FUNC_msg_apply_bytes: bpf_func_id = 61;
+pub const bpf_func_id_BPF_FUNC_msg_cork_bytes: bpf_func_id = 62;
+pub const bpf_func_id_BPF_FUNC_msg_pull_data: bpf_func_id = 63;
+pub const bpf_func_id_BPF_FUNC_bind: bpf_func_id = 64;
+pub const bpf_func_id_BPF_FUNC_xdp_adjust_tail: bpf_func_id = 65;
+pub const bpf_func_id_BPF_FUNC_skb_get_xfrm_state: bpf_func_id = 66;
+pub const bpf_func_id_BPF_FUNC_get_stack: bpf_func_id = 67;
+pub const bpf_func_id_BPF_FUNC_skb_load_bytes_relative: bpf_func_id = 68;
+pub const bpf_func_id_BPF_FUNC_fib_lookup: bpf_func_id = 69;
+pub const bpf_func_id_BPF_FUNC_sock_hash_update: bpf_func_id = 70;
+pub const bpf_func_id_BPF_FUNC_msg_redirect_hash: bpf_func_id = 71;
+pub const bpf_func_id_BPF_FUNC_sk_redirect_hash: bpf_func_id = 72;
+pub const bpf_func_id_BPF_FUNC_lwt_push_encap: bpf_func_id = 73;
+pub const bpf_func_id_BPF_FUNC_lwt_seg6_store_bytes: bpf_func_id = 74;
+pub const bpf_func_id_BPF_FUNC_lwt_seg6_adjust_srh: bpf_func_id = 75;
+pub const bpf_func_id_BPF_FUNC_lwt_seg6_action: bpf_func_id = 76;
+pub const bpf_func_id_BPF_FUNC_rc_repeat: bpf_func_id = 77;
+pub const bpf_func_id_BPF_FUNC_rc_keydown: bpf_func_id = 78;
+pub const bpf_func_id_BPF_FUNC_skb_cgroup_id: bpf_func_id = 79;
+pub const bpf_func_id_BPF_FUNC_get_current_cgroup_id: bpf_func_id = 80;
+pub const bpf_func_id_BPF_FUNC_get_local_storage: bpf_func_id = 81;
+pub const bpf_func_id_BPF_FUNC_sk_select_reuseport: bpf_func_id = 82;
+pub const bpf_func_id_BPF_FUNC_skb_ancestor_cgroup_id: bpf_func_id = 83;
+pub const bpf_func_id___BPF_FUNC_MAX_ID: bpf_func_id = 84;
 pub type bpf_func_id = ::std::os::raw::c_uint;
+pub const bpf_adj_room_mode_BPF_ADJ_ROOM_NET: bpf_adj_room_mode = 0;
+pub type bpf_adj_room_mode = ::std::os::raw::c_uint;
+pub const bpf_hdr_start_off_BPF_HDR_START_MAC: bpf_hdr_start_off = 0;
+pub const bpf_hdr_start_off_BPF_HDR_START_NET: bpf_hdr_start_off = 1;
+pub type bpf_hdr_start_off = ::std::os::raw::c_uint;
+pub const bpf_lwt_encap_mode_BPF_LWT_ENCAP_SEG6: bpf_lwt_encap_mode = 0;
+pub const bpf_lwt_encap_mode_BPF_LWT_ENCAP_SEG6_INLINE: bpf_lwt_encap_mode = 1;
+pub type bpf_lwt_encap_mode = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct __sk_buff {
@@ -981,12 +2289,21 @@ pub struct __sk_buff {
     pub tc_classid: __u32,
     pub data: __u32,
     pub data_end: __u32,
+    pub napi_id: __u32,
+    pub family: __u32,
+    pub remote_ip4: __u32,
+    pub local_ip4: __u32,
+    pub remote_ip6: [__u32; 4usize],
+    pub local_ip6: [__u32; 4usize],
+    pub remote_port: __u32,
+    pub local_port: __u32,
+    pub data_meta: __u32,
 }
 #[test]
 fn bindgen_test_layout___sk_buff() {
     assert_eq!(
         ::std::mem::size_of::<__sk_buff>(),
-        84usize,
+        144usize,
         concat!("Size of: ", stringify!(__sk_buff))
     );
     assert_eq!(
@@ -1164,6 +2481,96 @@ fn bindgen_test_layout___sk_buff() {
             stringify!(data_end)
         )
     );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).napi_id as *const _ as usize },
+        84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(napi_id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).family as *const _ as usize },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).remote_ip4 as *const _ as usize },
+        92usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(remote_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).local_ip4 as *const _ as usize },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(local_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).remote_ip6 as *const _ as usize },
+        100usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(remote_ip6)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).local_ip6 as *const _ as usize },
+        116usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(local_ip6)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).remote_port as *const _ as usize },
+        132usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(remote_port)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).local_port as *const _ as usize },
+        136usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(local_port)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__sk_buff>())).data_meta as *const _ as usize },
+        140usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__sk_buff),
+            "::",
+            stringify!(data_meta)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1311,22 +2718,281 @@ impl ::std::fmt::Debug for bpf_tunnel_key {
         write ! (f , "bpf_tunnel_key {{ tunnel_id: {:?}, __bindgen_anon_1: {:?}, tunnel_tos: {:?}, tunnel_ttl: {:?}, tunnel_ext: {:?}, tunnel_label: {:?} }}" , self . tunnel_id , self . __bindgen_anon_1 , self . tunnel_tos , self . tunnel_ttl , self . tunnel_ext , self . tunnel_label)
     }
 }
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_xfrm_state {
+    pub reqid: __u32,
+    pub spi: __u32,
+    pub family: __u16,
+    pub ext: __u16,
+    pub __bindgen_anon_1: bpf_xfrm_state__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_xfrm_state__bindgen_ty_1 {
+    pub remote_ipv4: __u32,
+    pub remote_ipv6: [__u32; 4usize],
+}
+#[test]
+fn bindgen_test_layout_bpf_xfrm_state__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_xfrm_state__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_xfrm_state__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_xfrm_state__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_xfrm_state__bindgen_ty_1))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_xfrm_state__bindgen_ty_1>())).remote_ipv4 as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_xfrm_state__bindgen_ty_1),
+            "::",
+            stringify!(remote_ipv4)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_xfrm_state__bindgen_ty_1>())).remote_ipv6 as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_xfrm_state__bindgen_ty_1),
+            "::",
+            stringify!(remote_ipv6)
+        )
+    );
+}
+impl Default for bpf_xfrm_state__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_xfrm_state__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_xfrm_state__bindgen_ty_1 {{ union }}")
+    }
+}
+#[test]
+fn bindgen_test_layout_bpf_xfrm_state() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_xfrm_state>(),
+        28usize,
+        concat!("Size of: ", stringify!(bpf_xfrm_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_xfrm_state>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_xfrm_state))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_xfrm_state>())).reqid as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_xfrm_state),
+            "::",
+            stringify!(reqid)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_xfrm_state>())).spi as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_xfrm_state),
+            "::",
+            stringify!(spi)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_xfrm_state>())).family as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_xfrm_state),
+            "::",
+            stringify!(family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_xfrm_state>())).ext as *const _ as usize },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_xfrm_state),
+            "::",
+            stringify!(ext)
+        )
+    );
+}
+impl Default for bpf_xfrm_state {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_xfrm_state {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write ! (f , "bpf_xfrm_state {{ reqid: {:?}, spi: {:?}, family: {:?}, ext: {:?}, __bindgen_anon_1: {:?} }}" , self . reqid , self . spi , self . family , self . ext , self . __bindgen_anon_1)
+    }
+}
+pub const bpf_ret_code_BPF_OK: bpf_ret_code = 0;
+pub const bpf_ret_code_BPF_DROP: bpf_ret_code = 2;
+pub const bpf_ret_code_BPF_REDIRECT: bpf_ret_code = 7;
+pub type bpf_ret_code = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_sock {
+    pub bound_dev_if: __u32,
+    pub family: __u32,
+    pub type_: __u32,
+    pub protocol: __u32,
+    pub mark: __u32,
+    pub priority: __u32,
+    pub src_ip4: __u32,
+    pub src_ip6: [__u32; 4usize],
+    pub src_port: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_sock() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_sock>(),
+        48usize,
+        concat!("Size of: ", stringify!(bpf_sock))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_sock>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_sock))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).bound_dev_if as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(bound_dev_if)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).family as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).type_ as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).protocol as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(protocol)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).mark as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(mark)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).priority as *const _ as usize },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(priority)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).src_ip4 as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(src_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).src_ip6 as *const _ as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(src_ip6)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock>())).src_port as *const _ as usize },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock),
+            "::",
+            stringify!(src_port)
+        )
+    );
+}
 pub const xdp_action_XDP_ABORTED: xdp_action = 0;
 pub const xdp_action_XDP_DROP: xdp_action = 1;
 pub const xdp_action_XDP_PASS: xdp_action = 2;
 pub const xdp_action_XDP_TX: xdp_action = 3;
+pub const xdp_action_XDP_REDIRECT: xdp_action = 4;
 pub type xdp_action = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct xdp_md {
     pub data: __u32,
     pub data_end: __u32,
+    pub data_meta: __u32,
+    pub ingress_ifindex: __u32,
+    pub rx_queue_index: __u32,
 }
 #[test]
 fn bindgen_test_layout_xdp_md() {
     assert_eq!(
         ::std::mem::size_of::<xdp_md>(),
-        8usize,
+        20usize,
         concat!("Size of: ", stringify!(xdp_md))
     );
     assert_eq!(
@@ -1354,7 +3020,1575 @@ fn bindgen_test_layout_xdp_md() {
             stringify!(data_end)
         )
     );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<xdp_md>())).data_meta as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(xdp_md),
+            "::",
+            stringify!(data_meta)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<xdp_md>())).ingress_ifindex as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(xdp_md),
+            "::",
+            stringify!(ingress_ifindex)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<xdp_md>())).rx_queue_index as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(xdp_md),
+            "::",
+            stringify!(rx_queue_index)
+        )
+    );
 }
+pub const sk_action_SK_DROP: sk_action = 0;
+pub const sk_action_SK_PASS: sk_action = 1;
+pub type sk_action = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_prog_info {
+    pub type_: __u32,
+    pub id: __u32,
+    pub tag: [__u8; 8usize],
+    pub jited_prog_len: __u32,
+    pub xlated_prog_len: __u32,
+    pub jited_prog_insns: __u64,
+    pub xlated_prog_insns: __u64,
+    pub load_time: __u64,
+    pub created_by_uid: __u32,
+    pub nr_map_ids: __u32,
+    pub map_ids: __u64,
+    pub name: [::std::os::raw::c_char; 16usize],
+    pub ifindex: __u32,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub netns_dev: __u64,
+    pub netns_ino: __u64,
+    pub nr_jited_ksyms: __u32,
+    pub nr_jited_func_lens: __u32,
+    pub jited_ksyms: __u64,
+    pub jited_func_lens: __u64,
+}
+#[test]
+fn bindgen_test_layout_bpf_prog_info() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_prog_info>(),
+        128usize,
+        concat!("Size of: ", stringify!(bpf_prog_info))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_prog_info>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_prog_info))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).type_ as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).id as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).tag as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(tag)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).jited_prog_len as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(jited_prog_len)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).xlated_prog_len as *const _ as usize },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(xlated_prog_len)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).jited_prog_insns as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(jited_prog_insns)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).xlated_prog_insns as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(xlated_prog_insns)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).load_time as *const _ as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(load_time)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).created_by_uid as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(created_by_uid)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).nr_map_ids as *const _ as usize },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(nr_map_ids)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).map_ids as *const _ as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(map_ids)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).name as *const _ as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(name)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).ifindex as *const _ as usize },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(ifindex)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).netns_dev as *const _ as usize },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(netns_dev)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).netns_ino as *const _ as usize },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(netns_ino)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).nr_jited_ksyms as *const _ as usize },
+        104usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(nr_jited_ksyms)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_prog_info>())).nr_jited_func_lens as *const _ as usize
+        },
+        108usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(nr_jited_func_lens)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).jited_ksyms as *const _ as usize },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(jited_ksyms)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_prog_info>())).jited_func_lens as *const _ as usize },
+        120usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_prog_info),
+            "::",
+            stringify!(jited_func_lens)
+        )
+    );
+}
+impl bpf_prog_info {
+    #[inline]
+    pub fn gpl_compatible(&self) -> __u32 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_gpl_compatible(&mut self, val: __u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(gpl_compatible: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let gpl_compatible: u32 = unsafe { ::std::mem::transmute(gpl_compatible) };
+            gpl_compatible as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_map_info {
+    pub type_: __u32,
+    pub id: __u32,
+    pub key_size: __u32,
+    pub value_size: __u32,
+    pub max_entries: __u32,
+    pub map_flags: __u32,
+    pub name: [::std::os::raw::c_char; 16usize],
+    pub ifindex: __u32,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub netns_dev: __u64,
+    pub netns_ino: __u64,
+    pub btf_id: __u32,
+    pub btf_key_type_id: __u32,
+    pub btf_value_type_id: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_map_info() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_map_info>(),
+        80usize,
+        concat!("Size of: ", stringify!(bpf_map_info))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_map_info>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_map_info))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).type_ as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).id as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).key_size as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(key_size)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).value_size as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(value_size)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).max_entries as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(max_entries)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).map_flags as *const _ as usize },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(map_flags)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).name as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(name)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).ifindex as *const _ as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(ifindex)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).netns_dev as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(netns_dev)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).netns_ino as *const _ as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(netns_ino)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).btf_id as *const _ as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(btf_id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).btf_key_type_id as *const _ as usize },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(btf_key_type_id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_map_info>())).btf_value_type_id as *const _ as usize },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_map_info),
+            "::",
+            stringify!(btf_value_type_id)
+        )
+    );
+}
+impl bpf_map_info {
+    #[inline]
+    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_btf_info {
+    pub btf: __u64,
+    pub btf_size: __u32,
+    pub id: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_btf_info() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_btf_info>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_btf_info))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_btf_info>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_btf_info))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_btf_info>())).btf as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_btf_info),
+            "::",
+            stringify!(btf)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_btf_info>())).btf_size as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_btf_info),
+            "::",
+            stringify!(btf_size)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_btf_info>())).id as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_btf_info),
+            "::",
+            stringify!(id)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_sock_addr {
+    pub user_family: __u32,
+    pub user_ip4: __u32,
+    pub user_ip6: [__u32; 4usize],
+    pub user_port: __u32,
+    pub family: __u32,
+    pub type_: __u32,
+    pub protocol: __u32,
+    pub msg_src_ip4: __u32,
+    pub msg_src_ip6: [__u32; 4usize],
+}
+#[test]
+fn bindgen_test_layout_bpf_sock_addr() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_sock_addr>(),
+        60usize,
+        concat!("Size of: ", stringify!(bpf_sock_addr))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_sock_addr>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_sock_addr))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).user_family as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(user_family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).user_ip4 as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(user_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).user_ip6 as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(user_ip6)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).user_port as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(user_port)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).family as *const _ as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).type_ as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).protocol as *const _ as usize },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(protocol)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).msg_src_ip4 as *const _ as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(msg_src_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_addr>())).msg_src_ip6 as *const _ as usize },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_addr),
+            "::",
+            stringify!(msg_src_ip6)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_sock_ops {
+    pub op: __u32,
+    pub __bindgen_anon_1: bpf_sock_ops__bindgen_ty_1,
+    pub family: __u32,
+    pub remote_ip4: __u32,
+    pub local_ip4: __u32,
+    pub remote_ip6: [__u32; 4usize],
+    pub local_ip6: [__u32; 4usize],
+    pub remote_port: __u32,
+    pub local_port: __u32,
+    pub is_fullsock: __u32,
+    pub snd_cwnd: __u32,
+    pub srtt_us: __u32,
+    pub bpf_sock_ops_cb_flags: __u32,
+    pub state: __u32,
+    pub rtt_min: __u32,
+    pub snd_ssthresh: __u32,
+    pub rcv_nxt: __u32,
+    pub snd_nxt: __u32,
+    pub snd_una: __u32,
+    pub mss_cache: __u32,
+    pub ecn_flags: __u32,
+    pub rate_delivered: __u32,
+    pub rate_interval_us: __u32,
+    pub packets_out: __u32,
+    pub retrans_out: __u32,
+    pub total_retrans: __u32,
+    pub segs_in: __u32,
+    pub data_segs_in: __u32,
+    pub segs_out: __u32,
+    pub data_segs_out: __u32,
+    pub lost_out: __u32,
+    pub sacked_out: __u32,
+    pub sk_txhash: __u32,
+    pub bytes_received: __u64,
+    pub bytes_acked: __u64,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_sock_ops__bindgen_ty_1 {
+    pub args: [__u32; 4usize],
+    pub reply: __u32,
+    pub replylong: [__u32; 4usize],
+}
+#[test]
+fn bindgen_test_layout_bpf_sock_ops__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_sock_ops__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_sock_ops__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_sock_ops__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_sock_ops__bindgen_ty_1))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops__bindgen_ty_1>())).args as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops__bindgen_ty_1),
+            "::",
+            stringify!(args)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_sock_ops__bindgen_ty_1>())).reply as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops__bindgen_ty_1),
+            "::",
+            stringify!(reply)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_sock_ops__bindgen_ty_1>())).replylong as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops__bindgen_ty_1),
+            "::",
+            stringify!(replylong)
+        )
+    );
+}
+impl Default for bpf_sock_ops__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_sock_ops__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_sock_ops__bindgen_ty_1 {{ union }}")
+    }
+}
+#[test]
+fn bindgen_test_layout_bpf_sock_ops() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_sock_ops>(),
+        184usize,
+        concat!("Size of: ", stringify!(bpf_sock_ops))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_sock_ops>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_sock_ops))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).op as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(op)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).family as *const _ as usize },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).remote_ip4 as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(remote_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).local_ip4 as *const _ as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(local_ip4)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).remote_ip6 as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(remote_ip6)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).local_ip6 as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(local_ip6)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).remote_port as *const _ as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(remote_port)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).local_port as *const _ as usize },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(local_port)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).is_fullsock as *const _ as usize },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(is_fullsock)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).snd_cwnd as *const _ as usize },
+        76usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(snd_cwnd)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).srtt_us as *const _ as usize },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(srtt_us)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_sock_ops>())).bpf_sock_ops_cb_flags as *const _ as usize
+        },
+        84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(bpf_sock_ops_cb_flags)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).state as *const _ as usize },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(state)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).rtt_min as *const _ as usize },
+        92usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(rtt_min)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).snd_ssthresh as *const _ as usize },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(snd_ssthresh)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).rcv_nxt as *const _ as usize },
+        100usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(rcv_nxt)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).snd_nxt as *const _ as usize },
+        104usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(snd_nxt)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).snd_una as *const _ as usize },
+        108usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(snd_una)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).mss_cache as *const _ as usize },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(mss_cache)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).ecn_flags as *const _ as usize },
+        116usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(ecn_flags)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).rate_delivered as *const _ as usize },
+        120usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(rate_delivered)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).rate_interval_us as *const _ as usize },
+        124usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(rate_interval_us)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).packets_out as *const _ as usize },
+        128usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(packets_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).retrans_out as *const _ as usize },
+        132usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(retrans_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).total_retrans as *const _ as usize },
+        136usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(total_retrans)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).segs_in as *const _ as usize },
+        140usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(segs_in)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).data_segs_in as *const _ as usize },
+        144usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(data_segs_in)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).segs_out as *const _ as usize },
+        148usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(segs_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).data_segs_out as *const _ as usize },
+        152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(data_segs_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).lost_out as *const _ as usize },
+        156usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(lost_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).sacked_out as *const _ as usize },
+        160usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(sacked_out)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).sk_txhash as *const _ as usize },
+        164usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(sk_txhash)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).bytes_received as *const _ as usize },
+        168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(bytes_received)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_sock_ops>())).bytes_acked as *const _ as usize },
+        176usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_sock_ops),
+            "::",
+            stringify!(bytes_acked)
+        )
+    );
+}
+impl Default for bpf_sock_ops {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_sock_ops {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write ! (f , "bpf_sock_ops {{ op: {:?}, __bindgen_anon_1: {:?}, family: {:?}, remote_ip4: {:?}, local_ip4: {:?}, remote_ip6: {:?}, local_ip6: {:?}, remote_port: {:?}, local_port: {:?}, is_fullsock: {:?}, snd_cwnd: {:?}, srtt_us: {:?}, bpf_sock_ops_cb_flags: {:?}, state: {:?}, rtt_min: {:?}, snd_ssthresh: {:?}, rcv_nxt: {:?}, snd_nxt: {:?}, snd_una: {:?}, mss_cache: {:?}, ecn_flags: {:?}, rate_delivered: {:?}, rate_interval_us: {:?}, packets_out: {:?}, retrans_out: {:?}, total_retrans: {:?}, segs_in: {:?}, data_segs_in: {:?}, segs_out: {:?}, data_segs_out: {:?}, lost_out: {:?}, sacked_out: {:?}, sk_txhash: {:?}, bytes_received: {:?}, bytes_acked: {:?} }}" , self . op , self . __bindgen_anon_1 , self . family , self . remote_ip4 , self . local_ip4 , self . remote_ip6 , self . local_ip6 , self . remote_port , self . local_port , self . is_fullsock , self . snd_cwnd , self . srtt_us , self . bpf_sock_ops_cb_flags , self . state , self . rtt_min , self . snd_ssthresh , self . rcv_nxt , self . snd_nxt , self . snd_una , self . mss_cache , self . ecn_flags , self . rate_delivered , self . rate_interval_us , self . packets_out , self . retrans_out , self . total_retrans , self . segs_in , self . data_segs_in , self . segs_out , self . data_segs_out , self . lost_out , self . sacked_out , self . sk_txhash , self . bytes_received , self . bytes_acked)
+    }
+}
+pub const BPF_SOCK_OPS_VOID: ::std::os::raw::c_uint = 0;
+pub const BPF_SOCK_OPS_TIMEOUT_INIT: ::std::os::raw::c_uint = 1;
+pub const BPF_SOCK_OPS_RWND_INIT: ::std::os::raw::c_uint = 2;
+pub const BPF_SOCK_OPS_TCP_CONNECT_CB: ::std::os::raw::c_uint = 3;
+pub const BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB: ::std::os::raw::c_uint = 4;
+pub const BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB: ::std::os::raw::c_uint = 5;
+pub const BPF_SOCK_OPS_NEEDS_ECN: ::std::os::raw::c_uint = 6;
+pub const BPF_SOCK_OPS_BASE_RTT: ::std::os::raw::c_uint = 7;
+pub const BPF_SOCK_OPS_RTO_CB: ::std::os::raw::c_uint = 8;
+pub const BPF_SOCK_OPS_RETRANS_CB: ::std::os::raw::c_uint = 9;
+pub const BPF_SOCK_OPS_STATE_CB: ::std::os::raw::c_uint = 10;
+pub const BPF_SOCK_OPS_TCP_LISTEN_CB: ::std::os::raw::c_uint = 11;
+pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+pub const BPF_TCP_ESTABLISHED: ::std::os::raw::c_uint = 1;
+pub const BPF_TCP_SYN_SENT: ::std::os::raw::c_uint = 2;
+pub const BPF_TCP_SYN_RECV: ::std::os::raw::c_uint = 3;
+pub const BPF_TCP_FIN_WAIT1: ::std::os::raw::c_uint = 4;
+pub const BPF_TCP_FIN_WAIT2: ::std::os::raw::c_uint = 5;
+pub const BPF_TCP_TIME_WAIT: ::std::os::raw::c_uint = 6;
+pub const BPF_TCP_CLOSE: ::std::os::raw::c_uint = 7;
+pub const BPF_TCP_CLOSE_WAIT: ::std::os::raw::c_uint = 8;
+pub const BPF_TCP_LAST_ACK: ::std::os::raw::c_uint = 9;
+pub const BPF_TCP_LISTEN: ::std::os::raw::c_uint = 10;
+pub const BPF_TCP_CLOSING: ::std::os::raw::c_uint = 11;
+pub const BPF_TCP_NEW_SYN_RECV: ::std::os::raw::c_uint = 12;
+pub const BPF_TCP_MAX_STATES: ::std::os::raw::c_uint = 13;
+pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_perf_event_value {
+    pub counter: __u64,
+    pub enabled: __u64,
+    pub running: __u64,
+}
+#[test]
+fn bindgen_test_layout_bpf_perf_event_value() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_perf_event_value>(),
+        24usize,
+        concat!("Size of: ", stringify!(bpf_perf_event_value))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_perf_event_value>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bpf_perf_event_value))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_perf_event_value>())).counter as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_perf_event_value),
+            "::",
+            stringify!(counter)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_perf_event_value>())).enabled as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_perf_event_value),
+            "::",
+            stringify!(enabled)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_perf_event_value>())).running as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_perf_event_value),
+            "::",
+            stringify!(running)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct bpf_cgroup_dev_ctx {
+    pub access_type: __u32,
+    pub major: __u32,
+    pub minor: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_cgroup_dev_ctx() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_cgroup_dev_ctx>(),
+        12usize,
+        concat!("Size of: ", stringify!(bpf_cgroup_dev_ctx))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_cgroup_dev_ctx>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_cgroup_dev_ctx))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_cgroup_dev_ctx>())).access_type as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_cgroup_dev_ctx),
+            "::",
+            stringify!(access_type)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_cgroup_dev_ctx>())).major as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_cgroup_dev_ctx),
+            "::",
+            stringify!(major)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_cgroup_dev_ctx>())).minor as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_cgroup_dev_ctx),
+            "::",
+            stringify!(minor)
+        )
+    );
+}
+pub const BPF_FIB_LKUP_RET_SUCCESS: ::std::os::raw::c_uint = 0;
+pub const BPF_FIB_LKUP_RET_BLACKHOLE: ::std::os::raw::c_uint = 1;
+pub const BPF_FIB_LKUP_RET_UNREACHABLE: ::std::os::raw::c_uint = 2;
+pub const BPF_FIB_LKUP_RET_PROHIBIT: ::std::os::raw::c_uint = 3;
+pub const BPF_FIB_LKUP_RET_NOT_FWDED: ::std::os::raw::c_uint = 4;
+pub const BPF_FIB_LKUP_RET_FWD_DISABLED: ::std::os::raw::c_uint = 5;
+pub const BPF_FIB_LKUP_RET_UNSUPP_LWT: ::std::os::raw::c_uint = 6;
+pub const BPF_FIB_LKUP_RET_NO_NEIGH: ::std::os::raw::c_uint = 7;
+pub const BPF_FIB_LKUP_RET_FRAG_NEEDED: ::std::os::raw::c_uint = 8;
+pub type _bindgen_ty_4 = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct bpf_fib_lookup {
+    pub family: __u8,
+    pub l4_protocol: __u8,
+    pub sport: __be16,
+    pub dport: __be16,
+    pub tot_len: __u16,
+    pub ifindex: __u32,
+    pub __bindgen_anon_1: bpf_fib_lookup__bindgen_ty_1,
+    pub __bindgen_anon_2: bpf_fib_lookup__bindgen_ty_2,
+    pub __bindgen_anon_3: bpf_fib_lookup__bindgen_ty_3,
+    pub h_vlan_proto: __be16,
+    pub h_vlan_TCI: __be16,
+    pub smac: [__u8; 6usize],
+    pub dmac: [__u8; 6usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_fib_lookup__bindgen_ty_1 {
+    pub tos: __u8,
+    pub flowinfo: __be32,
+    pub rt_metric: __u32,
+}
+#[test]
+fn bindgen_test_layout_bpf_fib_lookup__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_fib_lookup__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(bpf_fib_lookup__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_fib_lookup__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_fib_lookup__bindgen_ty_1))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_1>())).tos as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_1),
+            "::",
+            stringify!(tos)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_1>())).flowinfo as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_1),
+            "::",
+            stringify!(flowinfo)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_1>())).rt_metric as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_1),
+            "::",
+            stringify!(rt_metric)
+        )
+    );
+}
+impl Default for bpf_fib_lookup__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_fib_lookup__bindgen_ty_1 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_fib_lookup__bindgen_ty_1 {{ union }}")
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_fib_lookup__bindgen_ty_2 {
+    pub ipv4_src: __be32,
+    pub ipv6_src: [__u32; 4usize],
+}
+#[test]
+fn bindgen_test_layout_bpf_fib_lookup__bindgen_ty_2() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_fib_lookup__bindgen_ty_2>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_fib_lookup__bindgen_ty_2))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_fib_lookup__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_fib_lookup__bindgen_ty_2))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_2>())).ipv4_src as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_2),
+            "::",
+            stringify!(ipv4_src)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_2>())).ipv6_src as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_2),
+            "::",
+            stringify!(ipv6_src)
+        )
+    );
+}
+impl Default for bpf_fib_lookup__bindgen_ty_2 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_fib_lookup__bindgen_ty_2 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_fib_lookup__bindgen_ty_2 {{ union }}")
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union bpf_fib_lookup__bindgen_ty_3 {
+    pub ipv4_dst: __be32,
+    pub ipv6_dst: [__u32; 4usize],
+}
+#[test]
+fn bindgen_test_layout_bpf_fib_lookup__bindgen_ty_3() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_fib_lookup__bindgen_ty_3>(),
+        16usize,
+        concat!("Size of: ", stringify!(bpf_fib_lookup__bindgen_ty_3))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_fib_lookup__bindgen_ty_3>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_fib_lookup__bindgen_ty_3))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_3>())).ipv4_dst as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_3),
+            "::",
+            stringify!(ipv4_dst)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<bpf_fib_lookup__bindgen_ty_3>())).ipv6_dst as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup__bindgen_ty_3),
+            "::",
+            stringify!(ipv6_dst)
+        )
+    );
+}
+impl Default for bpf_fib_lookup__bindgen_ty_3 {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_fib_lookup__bindgen_ty_3 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "bpf_fib_lookup__bindgen_ty_3 {{ union }}")
+    }
+}
+#[test]
+fn bindgen_test_layout_bpf_fib_lookup() {
+    assert_eq!(
+        ::std::mem::size_of::<bpf_fib_lookup>(),
+        64usize,
+        concat!("Size of: ", stringify!(bpf_fib_lookup))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<bpf_fib_lookup>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bpf_fib_lookup))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).family as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(family)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).l4_protocol as *const _ as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(l4_protocol)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).sport as *const _ as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(sport)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).dport as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(dport)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).tot_len as *const _ as usize },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(tot_len)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).ifindex as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(ifindex)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).h_vlan_proto as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(h_vlan_proto)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).h_vlan_TCI as *const _ as usize },
+        50usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(h_vlan_TCI)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).smac as *const _ as usize },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(smac)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<bpf_fib_lookup>())).dmac as *const _ as usize },
+        58usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bpf_fib_lookup),
+            "::",
+            stringify!(dmac)
+        )
+    );
+}
+impl Default for bpf_fib_lookup {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for bpf_fib_lookup {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write ! (f , "bpf_fib_lookup {{ family: {:?}, l4_protocol: {:?}, sport: {:?}, dport: {:?}, tot_len: {:?}, ifindex: {:?}, __bindgen_anon_1: {:?}, __bindgen_anon_2: {:?}, __bindgen_anon_3: {:?}, h_vlan_proto: {:?}, h_vlan_TCI: {:?}, smac: {:?}, dmac: {:?} }}" , self . family , self . l4_protocol , self . sport , self . dport , self . tot_len , self . ifindex , self . __bindgen_anon_1 , self . __bindgen_anon_2 , self . __bindgen_anon_3 , self . h_vlan_proto , self . h_vlan_TCI , self . smac , self . dmac)
+    }
+}
+pub const bpf_task_fd_type_BPF_FD_TYPE_RAW_TRACEPOINT: bpf_task_fd_type = 0;
+pub const bpf_task_fd_type_BPF_FD_TYPE_TRACEPOINT: bpf_task_fd_type = 1;
+pub const bpf_task_fd_type_BPF_FD_TYPE_KPROBE: bpf_task_fd_type = 2;
+pub const bpf_task_fd_type_BPF_FD_TYPE_KRETPROBE: bpf_task_fd_type = 3;
+pub const bpf_task_fd_type_BPF_FD_TYPE_UPROBE: bpf_task_fd_type = 4;
+pub const bpf_task_fd_type_BPF_FD_TYPE_URETPROBE: bpf_task_fd_type = 5;
+pub type bpf_task_fd_type = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct bpf_create_map_attr {
@@ -2030,7 +5264,7 @@ extern "C" {
 extern "C" {
     pub fn bcc_buildsymcache_resolve(
         resolver: *mut ::std::os::raw::c_void,
-        trace: *mut [u8; 0usize],
+        trace: *mut bpf_stack_build_id,
         sym: *mut bcc_symbol,
     ) -> ::std::os::raw::c_int;
 }


### PR DESCRIPTION
PR #72 had incomplete bindings for bcc 0.20.0 due to the envionment
used to generate the bindings.

This change regenerates the bindings to correct the issues in the
previous release.
