### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/bccapi/v0_23_0.rs
+++ b/src/bccapi/v0_23_0.rs
@@ -537,10 +537,10 @@ impl bpf_insn {
     }
     #[inline]
     pub fn set_dst_reg(&mut self, val: __u8) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
+        
+            let val: u8 = unsafe { ::std::mem::transmute(val) };
             self._bitfield_1.set(0usize, 4u8, val as u64)
-        }
+        
     }
     #[inline]
     pub fn src_reg(&self) -> __u8 {
@@ -548,10 +548,10 @@ impl bpf_insn {
     }
     #[inline]
     pub fn set_src_reg(&mut self, val: __u8) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
+        
+            let val: u8 = unsafe { ::std::mem::transmute(val) };
             self._bitfield_1.set(4usize, 4u8, val as u64)
-        }
+        
     }
     #[inline]
     pub fn new_bitfield_1(dst_reg: __u8, src_reg: __u8) -> __BindgenBitfieldUnit<[u8; 1usize]> {
@@ -3291,10 +3291,10 @@ impl bpf_prog_info {
     }
     #[inline]
     pub fn set_gpl_compatible(&mut self, val: __u32) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
+        
+            let val: u32 = unsafe { ::std::mem::transmute(val) };
             self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
+        
     }
     #[inline]
     pub fn new_bitfield_1(gpl_compatible: __u32) -> __BindgenBitfieldUnit<[u8; 4usize]> {


### PR DESCRIPTION
In these functions you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

@brayniac Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 
